### PR TITLE
Defer the Turnstile api.js head script (parser-blocking on every page)

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -25,7 +25,7 @@ return [
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/less/forum.less')
         ->content(function (Document $document) {
-            $document->head[] = '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"></script>';
+            $document->head[] = '<script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" defer></script>';
         }),
 
     (new Extend\Frontend('admin'))


### PR DESCRIPTION
One-line fix for #5: add `defer` to the injected `api.js` script tag so it no longer parser-blocks every page render behind a third-party fetch (~150–400 ms at mobile p75; flagged by PSI's render-blocking audit and it delays FCP/LCP directly).

`defer` downloads in parallel and executes right after DOM parsing — still well before a user can open an auth modal, so `window.turnstile` is available when `TurnstileState.render()` runs. `render=explicit` semantics are unchanged.

Running in production on a Flarum 2.0.0-rc.4 forum: pages no longer block on `challenges.cloudflare.com`, and the sign-up widget renders and completes normally.

If you'd also like the `?onload=` + pending-render-queue hardening described in #5 (covers the theoretical modal-open-before-DOM-parsed race), happy to follow up with that separately.